### PR TITLE
Release notes for 1.1.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,0 +1,28 @@
+==================================
+scrapy-feedexporter-sftp changelog
+==================================
+
+1.1.0 (unreleased)
+==================
+
+-   Dropped support for Python 3.8 and lower, added support for Python 3.9 and
+    higher.
+
+-   Added a dependency on ``typing-extensions 3.6.2+`` on Python 3.10 and
+    lower.
+
+-   | Changed minimum versions of dependencies:
+    | ``paramiko``: ``1.16.0`` → ``2.10.0``
+    | ``scrapy``: ``1.0.3`` → ``2.0.0``
+
+-   Added a new ``FEED_STORAGE_SFTP_PKEY`` setting, which allows connecting to
+    an SFTP server using a private key instead of a password.
+
+-   Added Scrapy 2.12+ support.
+
+
+Earlier releases
+================
+
+Find the earlier commit history `at GitHub
+<https://github.com/scrapy-plugins/scrapy-feedexporter-sftp/commits/054f095bcf34a2768c64e1119375d1d8a9011dd5/>`_.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 dependencies = [
     "paramiko>=2.10.0",
     "scrapy>=2",
-    "typing_extensions; python_version < '3.11'",
+    "typing-extensions>=3.6.2; python_version < '3.11'",
 ]
 requires-python = ">=3.9"
 readme = "README.md"
@@ -37,6 +37,23 @@ Repository = "https://github.com/scrapy-plugins/scrapy-feedexporter-sftp"
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
+
+[tool.bumpversion]
+current_version = "1.0.4"
+commit = true
+tag = true
+tag_name = "{new_version}"
+
+[[tool.bumpversion.files]]
+filename = 'CHANGES.rst'
+search = "\\(unreleased\\)$"
+replace = "({now:%Y-%m-%d})"
+regex = true
+
+[[tool.bumpversion.files]]
+filename = "pyproject.toml"
+search = "version = \"{current_version}"
+replace = "version = \"{new_version}"
 
 [tool.ruff.lint]
 extend-select = [

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,7 @@ deps =
     {[testenv]deps}
     paramiko==2.10.0
     scrapy==2.0.0
+    typing-extensions==3.6.2; python_version < '3.11'
 
 [testenv:pre-commit]
 deps =


### PR DESCRIPTION
I considered increasing the major version, but decided to follow the logic suggested in the top comment from [this Reddit post](https://www.reddit.com/r/Python/comments/107g04w/would_you_increment_semver_when_removing_support/), i.e. only increase the minor version provided the API of the library itself does not break backward compatibility.

Resolves #5.